### PR TITLE
 Fix a bug about predictions saving

### DIFF
--- a/src/pixel_classifier.py
+++ b/src/pixel_classifier.py
@@ -114,7 +114,7 @@ def save_predictions(args, image_paths, preds):
 
     for i, pred in enumerate(preds):
         filename = image_paths[i].split('/')[-1].split('.')[0]
-        np.save(os.path.join(args['exp_dir'], 'predictions', filename + '.npy'), pred[0])
+        np.save(os.path.join(args['exp_dir'], 'predictions', filename + '.npy'), pred)
 
         pred = np.squeeze(pred)
         mask = colorize_mask(pred, palette)

--- a/src/pixel_classifier.py
+++ b/src/pixel_classifier.py
@@ -114,9 +114,9 @@ def save_predictions(args, image_paths, preds):
 
     for i, pred in enumerate(preds):
         filename = image_paths[i].split('/')[-1].split('.')[0]
+        pred = np.squeeze(pred)
         np.save(os.path.join(args['exp_dir'], 'predictions', filename + '.npy'), pred)
 
-        pred = np.squeeze(pred)
         mask = colorize_mask(pred, palette)
         Image.fromarray(mask).save(
             os.path.join(args['exp_dir'], 'visualizations', filename + '.jpg')


### PR DESCRIPTION
Shape of `pred` is `dim[:1]`, for example, `256*256`.
I think it should save prediction result with same dim as test image.